### PR TITLE
fix: zmsetup create InternalGAL with default polling

### DIFF
--- a/rpmconf/Env/crontabs/crontab.store
+++ b/rpmconf/Env/crontabs/crontab.store
@@ -13,7 +13,3 @@
 # Invoke "ComputeAggregateQuotaUsageRequest" periodically
 #
 15 2 * * *	/opt/zextras/libexec/zmcomputequotausage > /dev/null 2>&1
-#
-# Run zmgsaupdate util to trickeSync galsync accounts
-#
-49 0 * * 7	/opt/zextras/libexec/zmgsaupdate > /dev/null 2>&1

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5710,7 +5710,7 @@ sub configCreateDefaultDomainGALSyncAcct {
     my $zimbra_server = getLocalConfig ("zimbra_server_hostname");
     my $default_domain = (($newinstall) ? "$config{CREATEDOMAIN}" : "$config{zimbraDefaultDomainName}");
     my $galsyncacct = "galsync." . lc(genRandomPass()) . '@' . $default_domain ;
-    my $rc = runAsZextras("/opt/zextras/bin/zmgsautil createAccount -a $galsyncacct -n InternalGAL --domain $default_domain -s $zimbra_server -t zimbra -f _InternalGAL");
+    my $rc = runAsZextras("/opt/zextras/bin/zmgsautil createAccount -a $galsyncacct -n InternalGAL --domain $default_domain -s $zimbra_server -t zimbra -f _InternalGAL -p 7d");
     progress(($rc == 0) ? "done.\n" : "failed.\n");
     configLog("configCreateDefaultDomainGALSyncAcct") if ($rc == 0);
   }


### PR DESCRIPTION
Create InternalGAL with default polling of 7 days instead of using a dedicated crontab.
This way users will be able to change pollingInterval using CLI.

Note that the script zmgsaupdate won't be removed, but its cron entry will be removed.