### PR TITLE
feat: [CO-1] dhparam key must be unique for each install

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5940,11 +5940,10 @@ sub applyConfig {
   }
 
   # Create new dhparam key if new install
-  if($newinstall) {
-    progress( "Generating dhparam key..." );
-    runAsZextras ("/opt/zextras/bin/zmdhparam set -new 2048");
-    progress ( "done.\n" );
-  }
+  progress( "Generating dhparam key..." );
+  runAsZextras ("/opt/zextras/bin/zmdhparam set -new 2048");
+  progress ( "done.\n" );
+
 
   configLog ("END");
 

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5939,11 +5939,16 @@ sub applyConfig {
     runAsZextras ("/opt/zextras/bin/zmupdateauthkeys");
   }
 
-  # Create new dhparam key if new install
+  # Create new dhparam key for install
   progress( "Generating dhparam key..." );
   runAsZextras ("/opt/zextras/bin/zmdhparam set -new 2048");
   progress ( "done.\n" );
 
+  progress ( "Re-Starting servers..." );
+  runAsZextras ("/opt/zextras/bin/zmcontrol stop");
+  runAsZextras ("/opt/zextras/bin/zmcontrol start");
+  qx($SU "/opt/zextras/bin/zmcontrol status");
+  progress ( "done.\n" );
 
   configLog ("END");
 

--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5939,6 +5939,13 @@ sub applyConfig {
     runAsZextras ("/opt/zextras/bin/zmupdateauthkeys");
   }
 
+  # Create new dhparam key if new install
+  if($newinstall) {
+    progress( "Generating dhparam key..." );
+    runAsZextras ("/opt/zextras/bin/zmdhparam set -new 2048");
+    progress ( "done.\n" );
+  }
+
   configLog ("END");
 
   print H time(),": CONFIG SESSION COMPLETE\n";


### PR DESCRIPTION
This will generate a fresh dhparam key in the carbonio-bootstrap process.