### PR TITLE
revert: [CO-1] dhparam key must be unique for each install

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5952,17 +5952,6 @@ sub applyConfig {
     runAsZextras ("/opt/zextras/bin/zmupdateauthkeys");
   }
 
-  # Create new dhparam key for install
-  progress( "Generating dhparam key..." );
-  runAsZextras ("/opt/zextras/bin/zmdhparam set -new 2048");
-  progress ( "done.\n" );
-
-  progress ( "Re-Starting servers..." );
-  runAsZextras ("/opt/zextras/bin/zmcontrol stop");
-  runAsZextras ("/opt/zextras/bin/zmcontrol start");
-  qx($SU "/opt/zextras/bin/zmcontrol status");
-  progress ( "done.\n" );
-
   configLog ("END");
 
   print H time(),": CONFIG SESSION COMPLETE\n";


### PR DESCRIPTION
- remove the old implementation of dhparam key as we already have new one.