### PR TITLE
chore: [CO-180] add displayName to admin account

### DIFF
--- a/rpmconf/Install/zmsetup.pl
+++ b/rpmconf/Install/zmsetup.pl
@@ -5328,6 +5328,7 @@ sub configCreateDomain {
           "$config{CREATEADMIN} \'$config{CREATEADMINPASS}\' ".
           "zimbraAdminConsoleUIComponents cartBlancheUI ".
           "description \'Administrative Account\' ".
+          "displayName \'Carbonio Admin\' ".
           "zimbraIsAdminAccount TRUE");
         progress(($rc == 0) ? "done.\n" : "failed.\n");
       }


### PR DESCRIPTION
This will fill the displayName attribute for the default admin account while the carbonio-bootstrapping process. 